### PR TITLE
chore: bump lean version to `v4.6.0-rc1`, and bump Std accordingly

### DIFF
--- a/Leaff/Diff.lean
+++ b/Leaff/Diff.lean
@@ -1,5 +1,6 @@
 import Lean
 import Std.Lean.PersistentHashSet
+import Std.Lean.Name
 -- import Leaff.Deriving.Optics
 import Leaff.Hash
 import Leaff.HashSet

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -13,7 +13,7 @@
   {"url": "https://github.com/leanprover/std4.git",
    "type": "git",
    "subDir": null,
-   "rev": "0f6bc5b32bf5b0498902d3b5f0806c75530539d5",
+   "rev": "a61a015e2d419418f036ef089500c67429ac2154",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.5.0-rc1
+leanprover/lean4:v4.6.0-rc1


### PR DESCRIPTION
Bump the lean version, so that leaff is compatible with the latest version of Std.

The `Diff` file broke with an `invalid field 'isInternalDetail'` error. The docs showed that a function with this name exists in `Std.Lean.Name`, so I've added that import. Presumably this used to be in core and was moved to Std?